### PR TITLE
fix persistent data path

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Run:
 ```
 > docker run -it --rm -p 9756:9756 \
 >   -e "APIKEY=<your_api_key>" \
->   -e "AUTH=/pyecobee_db.db" \
+>   -e "AUTH=/pyecobee_db/pyecobee.db" \
 >   -v $(pwd)/pyecobee_db:/pyecobee_db \
 >   --name ecobee_prometheus_exporter \
 >   ecobee_prometheus_exporter


### PR DESCRIPTION
The existing path does not work correctly for persisting the ecobee application data.  This changes the README to use a path that will work correctly.

(After using the minor change here I'm successfully capturing ecobee data -- thanks for this project!)